### PR TITLE
🐛 GitHub Actionsのパーミッションの修正

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -3,6 +3,8 @@ on:
     push:
         branches:
             - main
+permissions:
+    contents: write
 jobs:
     test:
         uses: Joju-Matsumoto/actions/.github/workflows/go-test.yml@main


### PR DESCRIPTION
- releaseワークフローにpermissions.contents.writeが必要