### PR TITLE
明示的にフラグを付けないとDiscord通知をしないように修正

### DIFF
--- a/internal/adapter/discordnotifier/notifier.go
+++ b/internal/adapter/discordnotifier/notifier.go
@@ -15,6 +15,7 @@ import (
 type Config struct {
 	Token            string
 	TargetChannelIDs []string // TODO: 微妙な設計
+	logger           *slog.Logger
 }
 
 func New(cfg Config) (*discordNotifier, error) {
@@ -22,9 +23,15 @@ func New(cfg Config) (*discordNotifier, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if cfg.logger == nil {
+		cfg.logger = slog.Default()
+	}
+
 	return &discordNotifier{
 		sess:             sess,
 		targetChannelIDs: cfg.TargetChannelIDs,
+		logger:           cfg.logger,
 	}, nil
 }
 

--- a/internal/adapter/printnotifier/notifier.go
+++ b/internal/adapter/printnotifier/notifier.go
@@ -1,0 +1,30 @@
+package printnotifier
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/Joju-Matsumoto/oreilly-notification/internal/domain/model"
+	"github.com/Joju-Matsumoto/oreilly-notification/internal/domain/notifier"
+)
+
+func New(w io.Writer) *printBookNotifier {
+	return &printBookNotifier{
+		w: w,
+	}
+}
+
+type printBookNotifier struct {
+	w io.Writer
+}
+
+// NewBook implements notifier.BookNotifier.
+func (p *printBookNotifier) NewBook(ctx context.Context, books ...*model.Book) error {
+	for _, book := range books {
+		fmt.Fprintf(p.w, fmt.Sprintf("『%s』 %s\n", book.Title(), book.URL()))
+	}
+	return nil
+}
+
+var _ notifier.BookNotifier = (*printBookNotifier)(nil)


### PR DESCRIPTION
- fix: discordBookNotifierでエラーが発生するとpanicするバグの修正
  - slog.Loggerが初期化されていなかった
- 明示的なフラグ `--notify` `-n` を付けないとDiscord通知を送らないように修正
  - 初回実行時は通知を送りたくないのでデフォルト動作では通知を送らないようにした